### PR TITLE
Fix gradle build...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,10 @@ buildscript {
     // The buildscript {} block is odd: even though we applied dependencies.gradle above, the repositories therein
     // do not get included here. Instead, we must explicitly define the repos again. Yay for duplication.
     repositories {
+
         jcenter()
+        mavenCentral()
+
         maven {
             url "https://plugins.gradle.org/m2/"  // For Gradle plugins.
         }
@@ -22,6 +25,7 @@ buildscript {
     }
 
     dependencies {
+
         classpath libraries["gretty"]
         classpath libraries["shadow"]
         classpath libraries["coveralls-gradle-plugin"]
@@ -65,15 +69,15 @@ ext {
 
     SimpleDateFormat iso_8601_format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
     buildTimestamp = iso_8601_format.format(new Date())
-    
+
     // Project groups
     javaProjects = subprojects.findAll { it.plugins.withType(JavaPlugin) }
-    
+
     internalProjects = subprojects.findAll { it.path in [
             ':dap4', ':dap4:d4tests', ':dap4:d4ts', ':opendap:dtswar',
             ':docs', ':it', ':cdm-test', ':testUtil'
     ] }
-    
+
     publishedProjects = subprojects - internalProjects
 }
 

--- a/cdm/build.gradle
+++ b/cdm/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testCompile libraries["commons-io"]
     testCompile libraries["mockito"]
 
-    compile libraries["aws-java-sdk-s3"]
+    compile libraries["awssdk-s3"]
 
 
 }

--- a/cdm/src/main/java/thredds/filesystem/ControllerS3.java
+++ b/cdm/src/main/java/thredds/filesystem/ControllerS3.java
@@ -38,7 +38,7 @@ public class ControllerS3 implements MController {
             path = path.replaceFirst("s3fs:", "/data");
         }
         String[] _arr = path.replace("/data/", "").split("/", 2);
-        String bucket = _arr[0]; 
+        String bucket = _arr[0];
         String prefix = _arr[1];
         if (!prefix.endsWith("/")) {
             prefix = prefix + "/";
@@ -56,7 +56,7 @@ public class ControllerS3 implements MController {
             path = path.replaceFirst("s3fs:", "/data");
         }
         String[] _arr = path.replace("/data/", "").split("/", 2);
-        String bucket = _arr[0]; 
+        String bucket = _arr[0];
         String prefix = _arr[1];
         if (!prefix.endsWith("/")) {
             prefix = prefix + "/";
@@ -96,7 +96,7 @@ public class ControllerS3 implements MController {
                 throw new IllegalStateException("S3 ListObjectsV2 returned null on " + bucket + "/" + prefix);
             }
         }
-    
+
         public boolean hasNext() {
             return contents.hasNext();
         }

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -8,12 +8,12 @@ repositories {
     // https://blog.bintray.com/2015/02/09/android-studio-migration-from-maven-central-to-jcenter/
     jcenter()
     mavenCentral()  // JCenter isn't quite a superset of Maven Central.
-    
+
     // All of the hosted repositories below could be replaced with:
     //     url "https://artifacts.unidata.ucar.edu/repository/unidata-all/"
     // which is a group repository that contains all other repositories. However, I prefer to list all source
     // repos explicitly so that we know where all artifacts ultimately come from.
-    
+
     // Hosted release repositories.
     maven {
         // For "threddsIso", "visad" and "jj2000".
@@ -28,7 +28,7 @@ repositories {
         // still use. We should really try to eliminate our use of it.
         url "https://artifacts.unidata.ucar.edu/repository/unidata-3rdparty/"
     }
-    
+
     // Third-party repositories.
     maven {
         url "https://dl.bintray.com/cwardgar/maven/"  // For "gretty".
@@ -202,8 +202,14 @@ libraries["http-builder-ng-okhttp"] = "io.github.http-builder-ng:http-builder-ng
 
 ////////////////////////////// TDS ///////////////////////////////////////////
 
-libraries["aws-java-sdk-s3"] = "software.amazon.awssdk:s3:2.10.7"
-//libraries["aws-java-sdk-s3"] = dependencies.create("com.amazonaws:aws-java-sdk-s3:1.11.236") {
+
+libraries["awssdk-s3"] = "software.amazon.awssdk:s3:2.10.7"
+libraries["awssdk-sdk-core"] = "software.amazon.awssdk:sdk-core:2.16.42"
+
+libraries["aws-sdk-core"] = "com.amazonaws:aws-java-sdk-core:1.11.999"
+libraries["aws-sdk-s3"] = "com.amazonaws:aws-java-sdk-s3:1.11.999"
+
+// libraries["aws-java-sdk-s3"] = dependencies.create("com.amazonaws:aws-java-sdk-s3:1.11.236") {
 //    // exclude jackson deps so that they can be overridden
 //    // with 2.7.x deps to address security issue. See
 //    // https://github.com/aws/aws-sdk-java/issues/1159
@@ -214,7 +220,7 @@ libraries["aws-java-sdk-s3"] = "software.amazon.awssdk:s3:2.10.7"
 //    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
 //    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
 //    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-//}
+// }
 
 // replace the jackson.core libs that were excluded from aws-java-sdk-s3
 libraries["jackson-core"] = "com.fasterxml.jackson.core:jackson-core:2.9.9"
@@ -224,7 +230,7 @@ libraries["jackson-databind"] = "com.fasterxml.jackson.core:jackson-databind:2.9
 libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.17.0") {
     // the version of jna shipped with chronicle-map requires GLIBC 2.14
     // which prevents the use of the TDS on several versions of linux, such
-    // as CentOS and Hed Hat 6. We already include jna in netCDF-Java for
+    // as CentOS and Red Hat 6. We already include jna in netCDF-Java for
     // netCDF-C support, so we will rely on that version instead.
     // We should be able to get rid of this on the next release of chronicle-map,
     // as their snapshot BOM pom shows that they pulled back on jna.
@@ -252,7 +258,7 @@ libraries["oro"] = "oro:oro:2.0.8"
 
 libraries["thymeleaf-spring4"] = "org.thymeleaf:thymeleaf-spring4:3.0.11.RELEASE"
 
-versions["edal"] = "1.4.2-SNAPSHOT"
+versions["edal"] = "1.4.2"
 
 // needed for edal-common but this pulls in a newer version.
 libraries["ehcache"] = "net.sf.ehcache:ehcache:2.10.6"
@@ -348,7 +354,7 @@ configurations.all {
             }
         }
     }
-    
+
     // STAX is already included in Java 1.6+; no need for a third-party depenency.
     /*
         ./gradlew -q tds:dependencyInsight --configuration runtime --dependency stax-api
@@ -360,7 +366,7 @@ configurations.all {
                   ...
      */
     exclude group: 'stax', module: 'stax-api'
-    
+
     // Another SLF4J binding that we don't want.
     /*
         ./gradlew -q tds:dependencyInsight --configuration runtime --dependency slf4j-log4j12

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -202,30 +202,11 @@ libraries["http-builder-ng-okhttp"] = "io.github.http-builder-ng:http-builder-ng
 
 ////////////////////////////// TDS ///////////////////////////////////////////
 
-
+// Yes, we needs all four of these, at least for now.
 libraries["awssdk-s3"] = "software.amazon.awssdk:s3:2.10.7"
 libraries["awssdk-sdk-core"] = "software.amazon.awssdk:sdk-core:2.16.42"
-
-libraries["aws-sdk-core"] = "com.amazonaws:aws-java-sdk-core:1.11.999"
 libraries["aws-sdk-s3"] = "com.amazonaws:aws-java-sdk-s3:1.11.999"
-
-// libraries["aws-java-sdk-s3"] = dependencies.create("com.amazonaws:aws-java-sdk-s3:1.11.236") {
-//    // exclude jackson deps so that they can be overridden
-//    // with 2.7.x deps to address security issue. See
-//    // https://github.com/aws/aws-sdk-java/issues/1159
-//    // as of the time these were added, the versions of these were:
-//    // jackson-core: 2.6.7
-//    // jackson-annotations: 2.6.0
-//    // jackson-databind: 2.6.7.1
-//    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
-//    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
-//    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-// }
-
-// replace the jackson.core libs that were excluded from aws-java-sdk-s3
-libraries["jackson-core"] = "com.fasterxml.jackson.core:jackson-core:2.9.9"
-libraries["jackson-annotations"] = "com.fasterxml.jackson.core:jackson-annotations:2.9.9"
-libraries["jackson-databind"] = "com.fasterxml.jackson.core:jackson-databind:2.9.9"
+libraries["aws-sdk-core"] = "com.amazonaws:aws-java-sdk-core:1.11.999"
 
 libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.17.0") {
     // the version of jna shipped with chronicle-map requires GLIBC 2.14

--- a/gradle/any/java.gradle
+++ b/gradle/any/java.gradle
@@ -7,19 +7,18 @@ apply from: "$rootDir/gradle/any/javadoc.gradle"
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
-
 // These will only run when we execute the "publish" task, NOT "assemble".
 // That'll save us from a lot of unnecessary build time in the common case.
 task sourcesJar(type: Jar, dependsOn: classes, group: 'Documentation') {
     description = "Creates a JAR containing the main source code."
-    
+
     classifier = 'sources'
     from sourceSets.main.allSource
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc, group: 'Documentation') {
     description = "Creates a JAR containing the Javadoc that we've generated from the main source code."
-    
+
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
@@ -39,7 +38,7 @@ componentArtifacts << new DefaultPublishArtifact(tasks.javadocJar.archiveName, '
 // Will apply to "compileJava", "compileTestJava", "compileSourceSetJava", etc.
 tasks.withType(JavaCompile).all {
     options.encoding = 'UTF-8'
-    
+
     // Disable warnings about cross-compilation:
     // http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html#BHCIJIEG
     // This is usually fine, but see: http://www.draconianoverlord.com/2014/04/01/jdk-compatibility.html

--- a/gradle/root/fatJars.gradle
+++ b/gradle/root/fatJars.gradle
@@ -37,7 +37,7 @@ dependencies {
     ncIdv project(':legacy')
 
     tdmFat project(':tdm')
-    
+
     netcdfAll project(":cdm")
     netcdfAll project(":clcommon")
     netcdfAll project(":bufr")
@@ -48,11 +48,11 @@ dependencies {
     netcdfAll project(':visadCdm')  // For Gempak IOSPs.
 
     toolsUI project(':uicdm')
-    
+
     dap4lib project(':dap4:d4core')
     dap4lib project(':dap4:d4lib')
     dap4lib libraries["logback-classic"]
-    
+
     d4ts project(':dap4:d4ts')
 }
 
@@ -64,24 +64,26 @@ def fatJarTasks = []
 
 fatJarTasks << tasks.create(name: 'buildNcIdv', type: ShadowJar) {
     baseName = 'ncIdv'
+    zip64 true
+
     configurations = [project.configurations.ncIdv]
-    
+
     dependencies {
         exclude(dependency('c3p0:c3p0'))  // Transitive dependency dragged in by libraries["quartz"]
     }
-    
+
     // Filter out crap from libraries["visad"]
     exclude 'edu/wisc/**'
     exclude 'nom/**'
     exclude 'visad/**'
-    
+
     manifest.attributes 'Implementation-Title': 'ncIdv Module'
 }
 
 fatJarTasks << tasks.create(name: 'buildTdmFat', type: ShadowJar) {
     baseName = 'tdmFat'
     configurations = [project.configurations.tdmFat]
-    
+
     doFirst {
         manifest.attributes project(':tdm').tasks.jar.manifest.attributes
     }
@@ -90,7 +92,7 @@ fatJarTasks << tasks.create(name: 'buildTdmFat', type: ShadowJar) {
 fatJarTasks << tasks.create(name: 'buildNetcdfAll', type: ShadowJar) {
     baseName = 'netcdfAll'
     configurations = [project.configurations.netcdfAll]
-    
+
     doFirst {
         manifest.attributes project(':cdm').tasks.jar.manifest.attributes
     }
@@ -99,7 +101,7 @@ fatJarTasks << tasks.create(name: 'buildNetcdfAll', type: ShadowJar) {
 fatJarTasks << tasks.create(name: 'buildToolsUI', type: ShadowJar) {
     baseName = 'toolsUI'
     configurations = [project.configurations.toolsUI]
-    
+
     doFirst {
         manifest.attributes project(':uicdm').tasks.jar.manifest.attributes
     }
@@ -108,7 +110,7 @@ fatJarTasks << tasks.create(name: 'buildToolsUI', type: ShadowJar) {
 fatJarTasks << tasks.create(name: 'buildDap4Lib', type: ShadowJar) {
     baseName = 'dap4lib'
     configurations = [project.configurations.dap4lib]
-    
+
     doFirst {
         manifest.attributes project(':dap4:d4lib').tasks.jar.manifest.attributes
     }
@@ -117,7 +119,7 @@ fatJarTasks << tasks.create(name: 'buildDap4Lib', type: ShadowJar) {
 fatJarTasks << tasks.create(name: 'buildD4TS', type: ShadowJar) {
     baseName = 'd4ts'
     configurations = [project.configurations.d4ts]
-    
+
     doFirst {
         manifest.attributes project(':dap4:d4ts').tasks.jar.manifest.attributes
     }
@@ -127,7 +129,7 @@ fatJarTasks << tasks.create(name: 'buildD4TS', type: ShadowJar) {
 configure(fatJarTasks) {
     dependsOn configurations*.buildDependencies
     group = "shadow"
-    
+
     // Filter out crap from various other packages.
     exclude 'AUTHORS'
     exclude 'DATE'
@@ -144,7 +146,7 @@ configure(fatJarTasks) {
     exclude 'META-INF/*.RSA'
     exclude 'META-INF/*.txt'
     exclude 'META-INF/*.xml'
-    
+
     // Transformations
     append('META-INF/spring.handlers')
     append('META-INF/spring.schemas')

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -19,14 +19,14 @@ dependencies {
     compile libraries["guava"]
     compile libraries["jdom2"]
     compile libraries["jsr305"]
-    compile libraries["awssdk-s3"]  // For CrawlableDatasetAmazonS3.
-    compile libraries["jackson-core"]  // Replace what was in aws-java-sdk-s3
-    compile libraries["jackson-annotations"]  // Replace what was in aws-java-sdk-s3
-    compile libraries["jackson-databind"]  // Replace what was in aws-java-sdk-s3
 
+    // Yes, we actually need all 4 of these... Yeah, I know....
+    // For CrawlableDatasetAmazonS3.
+    compile libraries["awssdk-s3"]
     compile libraries["awssdk-sdk-core"]
-    compile libraries["aws-sdk-core"]
     compile libraries["aws-sdk-s3"]
+    compile libraries["aws-sdk-core"]
+
 
     compile libraries["slf4j-api"]
     testRuntime libraries["logback-classic"]

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -15,15 +15,19 @@ dependencies {
     compile project(":cdm")
     compile project(":grib")
     compile project(":opendap")
-    
+
     compile libraries["guava"]
     compile libraries["jdom2"]
     compile libraries["jsr305"]
-    compile libraries["aws-java-sdk-s3"]  // For CrawlableDatasetAmazonS3.
+    compile libraries["awssdk-s3"]  // For CrawlableDatasetAmazonS3.
     compile libraries["jackson-core"]  // Replace what was in aws-java-sdk-s3
     compile libraries["jackson-annotations"]  // Replace what was in aws-java-sdk-s3
     compile libraries["jackson-databind"]  // Replace what was in aws-java-sdk-s3
-    
+
+    compile libraries["awssdk-sdk-core"]
+    compile libraries["aws-sdk-core"]
+    compile libraries["aws-sdk-s3"]
+
     compile libraries["slf4j-api"]
     testRuntime libraries["logback-classic"]
 


### PR DESCRIPTION
Add imports for both the `com.amazonaws` and `software.amazon.awssdk` namespaces,
as the code uses both (but could probably get by w/ just one).

- Rename libraries to differentiate b/w them in build scripts.
- Add mavenCentral() to required repositiories.
- Enable zip64 support in fatJarTasks 'buildNcIdv'.